### PR TITLE
fix(http): clone Call before re-executing in HttpHelper retry

### DIFF
--- a/http/src/main/java/net/trellisframework/http/helper/HttpHelper.java
+++ b/http/src/main/java/net/trellisframework/http/helper/HttpHelper.java
@@ -188,25 +188,25 @@ public class HttpHelper {
 
     private static <T> Response<T> intercept(Call<T> func, Retry retry) throws IOException {
         if (retry != null) {
-        IOException lastException = null;
-        long delay = retry.getInitialDelayMillis();
-        for (int attempt = 1; attempt <= retry.getMaxAttempts(); attempt++) {
-            try {
-                Response<T> response = func.execute();
-                if (!retry.shouldRetry(response.code()) || attempt == retry.getMaxAttempts())
-                    return response;
-            } catch (IOException e) {
-                if (attempt == retry.getMaxAttempts())
-                    throw e;
-                lastException = e;
+            IOException lastException = null;
+            long delay = retry.getInitialDelayMillis();
+            for (int attempt = 1; attempt <= retry.getMaxAttempts(); attempt++) {
+                try {
+                    Response<T> response = (func.isExecuted() ? func.clone() : func).execute();
+                    if (!retry.shouldRetry(response.code()) || attempt == retry.getMaxAttempts())
+                        return response;
+                } catch (IOException e) {
+                    if (attempt == retry.getMaxAttempts())
+                        throw e;
+                    lastException = e;
+                }
+                retry.sleep(delay);
+                delay = retry.nextDelay(delay);
             }
-            retry.sleep(delay);
-            delay = retry.nextDelay(delay);
+            if (lastException != null)
+                throw lastException;
         }
-        if (lastException != null)
-            throw lastException;
-        }
-        return func.execute();
+        return (func.isExecuted() ? func.clone() : func).execute();
     }
 
     private static boolean isRedirect(Response<?> response) {


### PR DESCRIPTION
## Problem
`HttpHelper.intercept(Call, Retry)` re-executes the *same* Retrofit `Call` on every
retry attempt. A Retrofit `Call` is single-shot, so the 2nd attempt throws
`IllegalStateException("Already executed.")`. Any endpoint that actually retries
(e.g. a waterfall verify API returning 408) fails on the first retry.

## Fix
Use a fresh clone once the Call has already been executed:
`(func.isExecuted() ? func.clone() : func).execute();`
First attempt keeps the original Call; retries clone.